### PR TITLE
Changed requisition name of `hogan.js/lib/template.js`

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = function hoganify (file, options) {
         compiled = '';
 
     // Require Hogan.Template
-    compiled += 'var Template = require("hogan.js/lib/template.js");\n';
+    compiled += 'var Hogan = require("hogan.js/lib/template.js");\n';
 
     // Compile the template as string.
     template = Hogan.compile(buffer, { asString: true });


### PR DESCRIPTION
As `hogan.js/lib/template.js` exports an `Hogan` object itself (containing the `Template` property) the included var should be called `Hogan`.
Below, when `module.exports` line is created the correct Object is created by calling `Hogan.Template`.
